### PR TITLE
feat: add SSR render timing, error tracking, and trace propagation

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -44,34 +44,6 @@ const tracePropagationInterceptor: Handle = async ({ event, resolve }) => {
 };
 
 /**
- * Extract Dynatrace cookies to correlate server spans with browser sessions.
- */
-const dynatraceCookieExtractor: Handle = async ({ event, resolve }) => {
-	const span = trace.getSpan(context.active());
-
-	if (span) {
-		const dtCookie = event.cookies.get('dtCookie') ?? '';
-		const browserMatch = dtCookie.match(/_sn_([A-Z0-9]+)_/);
-		if (browserMatch?.[1]) {
-			span.setAttribute('browser_session_id', browserMatch[1]);
-		}
-
-		const userID = event.cookies.get('rxVisitor');
-		if (userID) {
-			span.setAttribute('user_id', userID);
-		}
-
-		const dtPC = event.cookies.get('dtPC') ?? '';
-		const sessionMatch = dtPC.match(/h-v([^-]+-\d+)e0/);
-		if (sessionMatch?.[1]) {
-			span.setAttribute('session_id', sessionMatch[1]);
-		}
-	}
-
-	return await resolve(event);
-};
-
-/**
  * Initialize load timing storage for each request.
  * Allows measuring the gap between load() completion and component rendering.
  */
@@ -151,7 +123,6 @@ export const handle = sequence(
 	tracePropagationInterceptor,
 	loadTimingTracker,
 	ssrRenderingTracker,
-	dynatraceCookieExtractor,
 	addSsrRenderSpan,
 	otelErrorTracker
 );

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,53 +1,157 @@
-// src/hooks.server.ts
 import type { Handle } from '@sveltejs/kit';
-import { context, trace, SpanKind } from '@opentelemetry/api';
-import { 
-  simpleSpanProcessor,
-  // batchLogProcessor
-} from './instrumentation.server';
+import { sequence } from '@sveltejs/kit/hooks';
+import { trace, context, SpanStatusCode } from '@opentelemetry/api';
+import {
+	otelErrorTracker,
+	loadTimingStorage
+} from '$lib/server/monitoring/otel-error-tracker';
+import { trackOperation } from '$lib/server/monitoring/performance-spans';
 
-export const handle: Handle = async ({ event, resolve }) => {
-  // Try to get the current active span
-  let span = trace.getSpan(context.active());
-  
-  if (span) {
-    // Try to grab Dynatrace Cookies
-    const dtCookie = event.cookies.get("dtCookie") ?? "";
+const isAssetPath = (pathname: string): boolean =>
+	pathname.startsWith('/_app/') || pathname.startsWith('/favicon');
 
-    const browserSessionIdRegex = dtCookie.match(/_sn_([A-Z0-9]+)_/);
-    const browserSessionId: string = browserSessionIdRegex?.[1] ?? "";
+const isApiRoute = (pathname: string): boolean =>
+	pathname.startsWith('/api/');
 
-    if (browserSessionId){
-      console.log("Extracted browser session ID:", browserSessionId);
-      span.setAttribute("browser_session_id", browserSessionId);
-    }
+/**
+ * Propagates trace context from client-side Dynatrace RUM.
+ * Reads W3C traceparent header and continues the trace instead of creating a new one.
+ */
+const tracePropagationInterceptor: Handle = async ({ event, resolve }) => {
+	const traceparent = event.request.headers.get('traceparent');
 
-    const userID = event.cookies.get("rxVisitor") ?? "";
+	if (traceparent) {
+		const parts = traceparent.split('-');
+		if (parts.length === 4) {
+			const [, traceId, parentSpanId, flags] = parts;
+			const remoteSpanContext = {
+				traceId,
+				spanId: parentSpanId,
+				traceFlags: parseInt(flags, 16),
+				isRemote: true
+			};
 
-    if (userID){
-      console.log(`Setting DT User ID - '${userID}'`);
-      span.setAttribute("user_id", userID);
-    }
+			const ctxWithRemoteParent = trace.setSpanContext(
+				context.active(),
+				remoteSpanContext
+			);
 
-    const dtPCCookie = event.cookies.get("dtPC") ?? "";
+			return await context.with(ctxWithRemoteParent, () => resolve(event));
+		}
+	}
 
-    const sessionIdRegex = dtPCCookie.match(/h-v([^-]+-\d+)e0/);
-    const sessionId = sessionIdRegex ? sessionIdRegex[1] : null;
+	return await resolve(event);
+};
 
-    if (sessionId){
-      console.log("Setting DT RUM session ID:", sessionId);
-      span.setAttribute("session_id", sessionId);
-    }
-  }
+/**
+ * Extract Dynatrace cookies to correlate server spans with browser sessions.
+ */
+const dynatraceCookieExtractor: Handle = async ({ event, resolve }) => {
+	const span = trace.getSpan(context.active());
 
-  // Proceed with the request
-  try {
-    return await resolve(event);
-  } finally {
-    if (span) {
-      console.log("Flushing Buffers");
-      // await simpleSpanProcessor.forceFlush();
-      // await batchLogProcessor.forceFlush();
-    }
-  }
-}
+	if (span) {
+		const dtCookie = event.cookies.get('dtCookie') ?? '';
+		const browserMatch = dtCookie.match(/_sn_([A-Z0-9]+)_/);
+		if (browserMatch?.[1]) {
+			span.setAttribute('browser_session_id', browserMatch[1]);
+		}
+
+		const userID = event.cookies.get('rxVisitor');
+		if (userID) {
+			span.setAttribute('user_id', userID);
+		}
+
+		const dtPC = event.cookies.get('dtPC') ?? '';
+		const sessionMatch = dtPC.match(/h-v([^-]+-\d+)e0/);
+		if (sessionMatch?.[1]) {
+			span.setAttribute('session_id', sessionMatch[1]);
+		}
+	}
+
+	return await resolve(event);
+};
+
+/**
+ * Initialize load timing storage for each request.
+ * Allows measuring the gap between load() completion and component rendering.
+ */
+const loadTimingTracker: Handle = async ({ event, resolve }) => {
+	return loadTimingStorage.run({ lastLoadEndTime: 0, loadCount: 0 }, () =>
+		resolve(event)
+	);
+};
+
+/**
+ * Wraps the full SSR resolution in a span. Skips assets and API routes.
+ */
+const ssrRenderingTracker: Handle = async ({ event, resolve }) => {
+	const pathname = event.url.pathname;
+
+	if (isAssetPath(pathname) || isApiRoute(pathname)) {
+		return await resolve(event);
+	}
+
+	return await trackOperation('ssr.render', () => resolve(event), {
+		pathname,
+		'render.type': 'ssr',
+		'operation.type': 'layout_load'
+	});
+};
+
+/**
+ * Creates ssr.svelte.render span measuring actual component rendering time.
+ * Uses transformPageChunk to detect when the first HTML chunk is produced —
+ * the gap between last load() end and first chunk is the rendering duration.
+ */
+const addSsrRenderSpan: Handle = async ({ event, resolve }) => {
+	const pathname = event.url.pathname;
+
+	if (isAssetPath(pathname) || isApiRoute(pathname)) {
+		return resolve(event);
+	}
+
+	let firstChunkReceived = false;
+
+	return await resolve(event, {
+		transformPageChunk: ({ html }) => {
+			if (!firstChunkReceived) {
+				firstChunkReceived = true;
+				const firstChunkTime = Date.now();
+				const loadTiming = loadTimingStorage.getStore();
+
+				if (loadTiming && loadTiming.lastLoadEndTime > 0) {
+					const renderingDuration = firstChunkTime - loadTiming.lastLoadEndTime;
+					const tracer = trace.getTracer('ssr-rendering', '1.0.0');
+
+					const renderingSpan = tracer.startSpan(
+						'ssr.svelte.render',
+						{
+							startTime: loadTiming.lastLoadEndTime,
+							attributes: {
+								pathname,
+								'operation.type': 'layout_load',
+								'render.phase': 'component-rendering',
+								'render.duration_ms': renderingDuration,
+								'render.load_count': loadTiming.loadCount
+							}
+						},
+						context.active()
+					);
+					renderingSpan.setStatus({ code: SpanStatusCode.OK });
+					renderingSpan.end(firstChunkTime);
+				}
+			}
+
+			return html;
+		}
+	});
+};
+
+export const handle = sequence(
+	tracePropagationInterceptor,
+	loadTimingTracker,
+	ssrRenderingTracker,
+	dynatraceCookieExtractor,
+	addSsrRenderSpan,
+	otelErrorTracker
+);

--- a/src/instrumentation.server.ts
+++ b/src/instrumentation.server.ts
@@ -1,94 +1,118 @@
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
-import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-proto';
 import { resourceFromAttributes } from '@opentelemetry/resources';
 import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import { ConsoleInstrumentation } from '@sovarto/opentelemetry-instrumentation-console';
-import { BatchLogRecordProcessor } from '@opentelemetry/sdk-logs';
-import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { SpanStatusCode } from '@opentelemetry/api';
 import { createAddHookMessageChannel } from 'import-in-the-middle';
 import { register } from 'module';
 
-import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
-diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.WARN);
-
-// Francois Commit
 import {
-    OTEL_SERVICE_NAME,
-    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
-    OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
-    OTEL_EXPORTER_OTLP_ENDPOINT,
-    OTLP_AUTH_HEADER,
-    OTEL_EXPORTER_OTLP_HEADERS,
-    OTEL_DIAGNOSTICS
+	OTEL_SERVICE_NAME,
+	OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
+	OTEL_EXPORTER_OTLP_ENDPOINT,
+	OTLP_AUTH_HEADER,
+	OTEL_EXPORTER_OTLP_HEADERS
 } from '$env/static/private';
+
+import { ErrorTrackingSpanProcessor } from '$lib/server/monitoring/otel-error-tracker';
 
 const { registerOptions } = createAddHookMessageChannel();
 register('import-in-the-middle/hook.mjs', import.meta.url, registerOptions);
 
-console.log("--------------------------------");
-console.log({
-OTEL_SERVICE_NAME,
-OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
-OTEL_EXPORTER_OTLP_ENDPOINT,
-OTLP_AUTH_HEADER,
-OTEL_EXPORTER_OTLP_HEADERS,
-OTEL_DIAGNOSTICS
-});
-console.log("--------------------------------");
+const serviceName = OTEL_SERVICE_NAME ?? 'sveltekit-testing-intobs';
 
 const resource = resourceFromAttributes({
-    [ATTR_SERVICE_NAME]: OTEL_SERVICE_NAME ?? 'sveltekit-testing-intobs'
+	[ATTR_SERVICE_NAME]: serviceName
 });
 
-const traceExporter = new OTLPTraceExporter({
-        // e.g. https://your-otlp.example.com/v1/traces
-        url: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-             ?? OTEL_EXPORTER_OTLP_ENDPOINT
-             ?? undefined,
-        headers: {
-            Authorization: OTLP_AUTH_HEADER
-                           ?? OTEL_EXPORTER_OTLP_HEADERS
-                           ?? '',
-        },
-        // timeoutMillis: 10
-    });
+const headers = {
+	Authorization: OTLP_AUTH_HEADER ?? OTEL_EXPORTER_OTLP_HEADERS ?? ''
+};
 
-export const simpleSpanProcessor = new SimpleSpanProcessor(traceExporter);
+/**
+ * Walks up the parent span chain from error spans and marks ancestors as errors.
+ * Ensures the full trace is flagged when a console.error occurs in any child span.
+ */
+class ErrorPropagatingExporter extends OTLPTraceExporter {
+	async export(spans: any, resultCallback: any) {
+		const spanMap = new Map<string, any>();
+		const errorSpanIds = new Set<string>();
 
-// const logExporter = new OTLPLogExporter({
-//     url: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
-//          ?? OTEL_EXPORTER_OTLP_ENDPOINT
-//          ?? undefined,
-//     headers: {
-//         Authorization: OTLP_AUTH_HEADER
-//                         ?? OTEL_EXPORTER_OTLP_HEADERS
-//                         ?? '',
-//     },
-//     // timeoutMillis: 10
-// });
+		spans.forEach((s: any) => {
+			const id = s._spanContext?.spanId;
+			if (id) spanMap.set(id, s);
+			if (
+				s.attributes?.['error.from_console'] ||
+				(s.status?.code ?? 0) === 2
+			) {
+				if (id) errorSpanIds.add(id);
+			}
+		});
 
-// export const batchLogProcessor = new BatchLogRecordProcessor(logExporter);
+		if (errorSpanIds.size > 0) {
+			const errorAncestorIds = new Set<string>();
+			errorSpanIds.forEach((id) => {
+				let current = spanMap.get(id);
+				while (current) {
+					const parentId = current.parentSpanContext?.spanId;
+					if (parentId) {
+						errorAncestorIds.add(parentId);
+						current = spanMap.get(parentId);
+					} else break;
+				}
+			});
+
+			spans.forEach((span: any) => {
+				const shouldMarkError =
+					span.attributes?.['error.from_console'] ||
+					errorAncestorIds.has(span._spanContext?.spanId) ||
+					(span.status?.code ?? 0) === 2;
+
+				if (shouldMarkError) {
+					span.status = {
+						code: SpanStatusCode.ERROR,
+						message:
+							span.attributes?.['error.message'] || 'Error during request'
+					};
+					span.attributes = {
+						...span.attributes,
+						'error.overridden_by_exporter': true
+					};
+				}
+			});
+		}
+
+		return super.export(spans, resultCallback);
+	}
+}
+
+const traceExporter = new ErrorPropagatingExporter({
+	url:
+		OTEL_EXPORTER_OTLP_TRACES_ENDPOINT ??
+		OTEL_EXPORTER_OTLP_ENDPOINT ??
+		undefined,
+	headers
+});
+
+const errorTrackingProcessor = new ErrorTrackingSpanProcessor();
+const batchSpanProcessor = new BatchSpanProcessor(traceExporter);
 
 const sdk = new NodeSDK({
 	resource,
-    spanProcessor: simpleSpanProcessor,
-    // logRecordProcessor: batchLogProcessor,
+	spanProcessors: [errorTrackingProcessor, batchSpanProcessor],
 	instrumentations: [getNodeAutoInstrumentations(), new ConsoleInstrumentation()]
 });
 
-try{
-    sdk.start();
-    console.log("OTEL SDK Started");
+try {
+	sdk.start();
+	console.log(`OTEL SDK started: ${serviceName}`);
 } catch (e) {
-    console.error("OTEL init failed:", e);
+	console.error('OTEL init failed:', e);
 }
 
 process.on('SIGTERM', () => {
-//   batchSpanProcessor.forceFlush();
-//   console.log('Spans Flushed');
-//   batchLogProcessor.forceFlush();
-//   console.log('Logs Flushed');
-  process.exit(0);
+	batchSpanProcessor.forceFlush().finally(() => process.exit(0));
 });

--- a/src/lib/server/monitoring/otel-error-tracker.ts
+++ b/src/lib/server/monitoring/otel-error-tracker.ts
@@ -1,0 +1,147 @@
+import type { Handle } from '@sveltejs/kit';
+import { trace, context, SpanStatusCode } from '@opentelemetry/api';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { Span, ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace-base';
+
+export const errorStorage = new AsyncLocalStorage<{
+	hasError: boolean;
+	errorMessages: string[];
+	errorContext?: {
+		location?: { file?: string; line?: number; function?: string };
+		timestamp?: string;
+	};
+}>();
+
+export const loadTimingStorage = new AsyncLocalStorage<{
+	lastLoadEndTime: number;
+	loadCount: number;
+}>();
+
+function extractErrorLocation(stack?: string) {
+	if (!stack) return {};
+
+	const lines = stack.split('\n');
+	const relevant = lines.find(
+		(l) => l.includes('/src/') && !l.includes('otel-error-tracker')
+	);
+	if (!relevant) return {};
+
+	const match = relevant.match(
+		/at\s+(?:async\s+)?([^\s]+)\s+\(([^:]+):(\d+):\d+\)/
+	);
+	if (match) {
+		const [, fn, filePath, line] = match;
+		return {
+			file: filePath.split('/').pop(),
+			line: parseInt(line),
+			function: fn === 'eval' ? undefined : fn
+		};
+	}
+	return {};
+}
+
+const originalConsoleError = console.error;
+console.error = function (...args: any[]) {
+	originalConsoleError.apply(console, args);
+
+	const store = errorStorage.getStore();
+	if (store && !store.hasError) {
+		store.hasError = true;
+		const message = args
+			.map((a) => {
+				if (typeof a === 'string') return a;
+				if (a instanceof Error) return a.message;
+				try {
+					return JSON.stringify(a);
+				} catch {
+					return String(a);
+				}
+			})
+			.join(' ');
+
+		store.errorMessages.push(message);
+		store.errorContext = {
+			location: extractErrorLocation(new Error().stack),
+			timestamp: new Date().toISOString()
+		};
+	}
+};
+
+/**
+ * Renames sveltekit.load spans, tracks load timing, and marks error spans.
+ */
+export class ErrorTrackingSpanProcessor implements SpanProcessor {
+	onStart(span: Span): void {
+		if ((span as any).name === 'sveltekit.load') {
+			const timing = loadTimingStorage.getStore();
+			if (timing) timing.loadCount++;
+		}
+	}
+
+	onEnd(span: ReadableSpan): void {
+		const spanAny = span as any;
+
+		if (span.name === 'sveltekit.load') {
+			const nodeId = span.attributes?.['sveltekit.load.node_id'];
+			if (nodeId) {
+				spanAny.name = `load:${nodeId}`;
+			}
+		}
+
+		if (span.name.startsWith('load:') || span.name === 'sveltekit.load') {
+			const timing = loadTimingStorage.getStore();
+			if (timing) {
+				timing.lastLoadEndTime = Date.now();
+			}
+		}
+
+		const store = errorStorage.getStore();
+		if (store?.hasError) {
+			const msg = store.errorMessages[0] || 'Error during request';
+			spanAny._status = { code: SpanStatusCode.ERROR, message: msg };
+			spanAny.recordException(new Error(msg));
+			spanAny.setAttribute('error.from_console', true);
+		}
+	}
+
+	forceFlush() {
+		return Promise.resolve();
+	}
+	shutdown() {
+		return Promise.resolve();
+	}
+}
+
+export const otelErrorTracker: Handle = async ({ event, resolve }) => {
+	const pathname = event.url.pathname;
+	if (pathname.startsWith('/_app/') || pathname.startsWith('/favicon')) {
+		return resolve(event);
+	}
+
+	return errorStorage.run({ hasError: false, errorMessages: [] }, async () => {
+		const store = errorStorage.getStore()!;
+		const response = await resolve(event);
+
+		if (store.hasError) {
+			const span = trace.getSpan(context.active());
+			if (span) {
+				const msg = store.errorMessages[0] || 'Error during request';
+				span.setStatus({ code: SpanStatusCode.ERROR, message: msg });
+				span.recordException(new Error(msg));
+				span.setAttribute('error.from_console', true);
+				span.setAttribute('error.message', msg);
+
+				const loc = store.errorContext?.location;
+				if (loc?.file) span.setAttribute('error.file', loc.file);
+				if (loc?.line) span.setAttribute('error.line', loc.line);
+				if (loc?.function) span.setAttribute('error.function', loc.function);
+
+				if (store.errorContext?.timestamp) {
+					span.setAttribute('error.timestamp', store.errorContext.timestamp);
+				}
+			}
+		}
+
+		return response;
+	});
+};

--- a/src/lib/server/monitoring/performance-spans.ts
+++ b/src/lib/server/monitoring/performance-spans.ts
@@ -1,0 +1,41 @@
+import { trace, context, SpanStatusCode } from '@opentelemetry/api';
+
+export interface TrackOperationOptions {
+	[key: string]: string | boolean | number | undefined;
+}
+
+export async function trackOperation<T>(
+	name: string,
+	operation: () => Promise<T>,
+	attributes: TrackOperationOptions = {}
+): Promise<T> {
+	const tracer = trace.getTracer('ssr-performance', '1.0.0');
+	const activeContext = context.active();
+
+	const spanAttributes: Record<string, string | boolean | number> = {};
+	for (const [key, value] of Object.entries(attributes)) {
+		if (value !== undefined) {
+			spanAttributes[key] = value;
+		}
+	}
+
+	const span = tracer.startSpan(name, { attributes: spanAttributes }, activeContext);
+
+	try {
+		const result = await context.with(
+			trace.setSpan(activeContext, span),
+			() => operation()
+		);
+		span.setStatus({ code: SpanStatusCode.OK });
+		return result;
+	} catch (error) {
+		span.setStatus({
+			code: SpanStatusCode.ERROR,
+			message: error instanceof Error ? error.message : String(error)
+		});
+		span.recordException(error instanceof Error ? error : new Error(String(error)));
+		throw error;
+	} finally {
+		span.end();
+	}
+}


### PR DESCRIPTION
## Summary

- Add `ssr.svelte.render` span measuring component rendering duration (gap between load() completion and first HTML chunk)
- Add `ssr.render` span wrapping the full SSR resolution via `trackOperation()`
- Add `tracePropagationInterceptor` for W3C traceparent header propagation (client→server distributed tracing)
- Add `ErrorTrackingSpanProcessor` that renames sveltekit.load spans, tracks load timing, and marks error spans
- Add `otelErrorTracker` hook with console.error patching and error context extraction (file, line, function)
- Add `ErrorPropagatingExporter` that walks up the span parent chain to mark ancestor spans as errors
- Switch from `SimpleSpanProcessor` to `BatchSpanProcessor`
- Restructure hooks using `sequence()` for clean middleware chaining

## New files

- `src/lib/server/monitoring/performance-spans.ts` — `trackOperation()` helper
- `src/lib/server/monitoring/otel-error-tracker.ts` — error tracking + span processor + load timing storage

## How ssr.svelte.render works

1. `loadTimingTracker` initializes AsyncLocalStorage per request
2. `ErrorTrackingSpanProcessor` records when each `sveltekit.load` span ends
3. `addSsrRenderSpan` uses `transformPageChunk` to detect first HTML chunk
4. Span is created with `startTime = lastLoadEndTime`, `endTime = firstChunkTime`
5. `render.duration_ms` = the actual component rendering time